### PR TITLE
Adiciona chamada à API para exibir jogo do dia na Home

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+  remotePatterns: [
+    {
+      protocol: 'https',
+      hostname: 'sujeitoprogramador.com',
+    }
+  ]
+  }
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,37 @@
+import Container from "@/componentes/container";
+import { GameProps } from "@/utils/types/games";
 import Image from "next/image";
+import Link from "next/link"
 
-export default function Home() {
+async function getDalyGame() {
+  try {
+    const res = await fetch(`${process.env.NEXT_API_URL}/next-api/?api=game_day`)
+    return res.json();
+  } catch (err) {
+    throw new Error("Faliled to fetch data")
+  }
+}
+
+export default async function Home() {
+
+  const daylyGame: GameProps = await getDalyGame()
+
   return (
-    <h1>Home Page</h1>
+    <main className="w-full">
+      <Container>
+        <h1 className="text-center font-bold text-xl text-black mt-8 mb-5">Separamos um jogo exclusivo pra você</h1>
+        <Link href={`/game/${daylyGame.id}`}>
+          <section className="w-full bg-black rounded-lg">
+            <Image
+              src={daylyGame.image_url}
+              alt={daylyGame.title}
+              priority={true}
+              quality={100}
+              fill={true}
+            />
+          </section>
+        </Link>
+      </Container>
+    </main >
   );
 }

--- a/src/componentes/container/index.tsx
+++ b/src/componentes/container/index.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function Container({ children }: { children: ReactNode }) {
+    return (
+        <div className="max-w-screen-xl mx-auto px-3">
+            {children}
+        </div>
+    );
+}

--- a/src/componentes/header/index.tsx
+++ b/src/componentes/header/index.tsx
@@ -1,4 +1,4 @@
-import logoImg from '../../../public/logo.svg'
+// import logoImg from '../../../public/logo.svg'
 import Image from 'next/image'
 import Link from 'next/link'
 import { LiaGamepadSolid } from 'react-icons/lia'
@@ -10,11 +10,14 @@ export function Header() {
                 <nav className='flex justify-center items-center gap-4'>
                     <Link href="/">
                         <Image
-                            src={logoImg}
-                            alt='Logo do site dalygames'
+                            src="/logo.svg"
+                            alt="Logo do site dalygames"
+                            width={150}   // ajuste conforme tamanho do seu logo
+                            height={50}   // ajuste conforme tamanho do seu logo
                             quality={100}
-                            priority={true}
+                            priority
                         />
+
                     </Link>
                     <Link href="/">
                         Games

--- a/src/utils/types/games.ts
+++ b/src/utils/types/games.ts
@@ -1,0 +1,9 @@
+export interface GameProps {
+    id: number;
+    title: string;
+    description: string;
+    image_url: string;
+    platforms: string[];
+    categories: string[];
+    realease: string;
+}


### PR DESCRIPTION
### Descrição

Este PR implementa a funcionalidade de buscar e exibir o **jogo do dia** na página inicial (`Home`).
O jogo é carregado dinamicamente a partir da API configurada em `NEXT_API_URL`.

### Alterações

* Criação da função assíncrona `getDalyGame()` que consome a rota `/next-api/?api=game_day`.
* Tipagem da resposta utilizando `GameProps`.
* Renderização do título e imagem do jogo do dia dentro de um `Link` que leva para a página `/game/[id]`.
* Uso do componente `Container` para manter o layout consistente.
* Inclusão de `next/image` com `fill`, `priority` e `quality` para otimizar a imagem.

