### PR TITLE
Listagem de Jogos e Card de Jogos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,19 +4,31 @@ import Image from "next/image";
 import Link from "next/link";
 import { BsArrowRightSquare } from "react-icons/bs";
 import { Input } from "@/componentes/input";
+import GameCard from "@/componentes/GameCard";
 
 async function getDalyGame() {
   try {
-    const res = await fetch(`${process.env.NEXT_API_URL}/next-api/?api=game_day`)
+    const res = await fetch(`${process.env.NEXT_API_URL}/next-api/?api=game_day`, { next: { revalidate: 320 } })
     return res.json();
   } catch (err) {
     throw new Error("Faliled to fetch data")
   }
 }
 
+async function getDalyData() {
+  try {
+    const res = await fetch(`${process.env.NEXT_API_URL}/next-api/?api=games`, { next: { revalidate: 320 } })
+    return res.json();
+  } catch (err) {
+    throw new Error("Faliled to fetch data")
+  }
+}
+
+
 export default async function Home() {
 
   const daylyGame: GameProps = await getDalyGame()
+  const data: GameProps[] = await getDalyData()
 
   return (
     <main className="w-full">
@@ -42,6 +54,14 @@ export default async function Home() {
           </section>
         </Link>
         <Input />
+
+        <h2 className="text-lg font-bold l text-black mt-8 mb-5">Jogos para conhecer</h2>
+
+        <section className="grid gap-7 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {data.map((item) => (
+            <GameCard key={item.id} data={item} />
+          ))}
+        </section>
       </Container>
     </main >
   );

--- a/src/componentes/GameCard/index.tsx
+++ b/src/componentes/GameCard/index.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link"
+import Image from "next/image"
+import { BiCircle, BiRightArrowCircle } from "react-icons/bi"
+import { GameProps } from "@/utils/types/games"
+
+interface GameCardProps {
+    data: GameProps
+}
+
+export default function GameCard({ data }: GameCardProps) {
+    return (
+        <Link href={`/game/${data.id}`}>
+            <section className="full bg-slate-200 rounded-lg p-4 mb-5">
+                <div className="relative w-full h-56 transition-all duration-300">
+                    <Image
+                        className="rounded-lg"
+                        src={data.image_url}
+                        alt={data.title}
+                        fill={true}
+                        quality={100}
+                        sizes="(max-width: 768px) 100vw, (max-width: 1200px)44vw"
+                    />
+                </div>
+                <div className="flex items-center mt-4 justify-between">
+                    <p className="text-sm font-bold px-2 text-black text-ellipsis 
+                    truncate whitespace-nowrap overflow-hidden">${data.title}</p>
+                    <BiRightArrowCircle />
+                </div>
+            </section>
+        </Link>
+    )
+}


### PR DESCRIPTION
Este PR adiciona a funcionalidade de **listagem de jogos**, incluindo:

* Exibição de um **jogo do dia** em destaque.
* Listagem de **jogos recomendados** com layout responsivo.
* Criação do componente **`GameCard`** para padronizar a exibição de cada jogo.

#### Alterações realizadas

* **Página Home (`page.tsx` ou `index.tsx`)**

  * Adicionada chamada à API para buscar:

    * `game_day` → jogo exclusivo do dia.
    * `games` → lista de jogos gerais.
  * Exibição do jogo do dia em destaque com imagem, título e link para página individual.
  * Inclusão de campo de busca (`Input`).
  * Renderização de listagem de jogos utilizando o componente `GameCard`.

* **Componente `GameCard`**

  * Criado para exibir informações básicas de um jogo (imagem e título).
  * Layout responsivo com `Next/Image` para otimização.
  * Inclui botão de acesso rápido (`BiRightArrowCircle`).
  * Redireciona para a página de detalhes do jogo.

